### PR TITLE
Add config for Google Analytics ID

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3488,3 +3488,7 @@ USER_STATE_BATCH_SIZE = 5000
 from openedx.core.djangoapps.plugins import plugin_apps, plugin_settings, constants as plugin_constants
 INSTALLED_APPS.extend(plugin_apps.get_apps(plugin_constants.ProjectType.LMS))
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.COMMON)
+
+######################### Settings for LUMS #######################
+
+GOOGLE_ANALYTICS_ID = ''

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1123,3 +1123,7 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+######################### Settings for LUMS #######################
+
+GOOGLE_ANALYTICS_ID = AUTH_TOKENS.get('GOOGLE_ANALYTICS_ID', GOOGLE_ANALYTICS_ID)


### PR DESCRIPTION
**Related PR**: https://github.com/edly-io/edly-lums-theme/pull/31
Add configurations for `Google Analytics ID` in the config files (`lms/env/common.py` and `lms/env/production.py).

This config is being added to disable GA on the staging server where value for this config will not be set.
This will disable the GA scripts in lums theme repo