### PR TITLE
Hide discussion "subscribe email" row

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
+++ b/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
@@ -44,19 +44,7 @@
           <span class="row-description"><%- gettext("Follow or unfollow posts") %></span>
         </td>
       </tr>
-      <tr class="helpgrid-row helpgrid-row-notification">
-        <th scope="row" class="row-title"><%- gettext('Receive updates') %></td>
-        <td class="row-item-full" colspan="3">
-          <label for="email-setting-checkbox">
-            <span class="sr"><%- gettext("Toggle Notifications Setting") %></span>
-            <span class="notification-checkbox">
-              <input type="checkbox" id="email-setting-checkbox" class="email-setting" name="email-notification"/>
-              <span class="icon fa fa-envelope" aria-hidden="true"></span>
-            </span>
-          </label>
-          <span class="row-description"><%- gettext("Check this box to receive an email digest once a day notifying you about new, unread activity from posts you are following.") %></span>
-        </td>
-      </tr>
+
     </table>
   <% } %>
 </div>


### PR DESCRIPTION
Hide the row in the discussion page that has the button to
subscribe/unsubscribe to a discussion forum for a course.