### PR TITLE
Disable Add Post Submit Button Default

### DIFF
--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -133,6 +133,8 @@
                 'keypress .forum-new-post-form input:not(.wmd-input)': function(event) {
                     return DiscussionUtil.ignoreEnterKey(event);
                 },
+                'input .forum-new-post-form .wmd-input ': 'toggleSubmitButton',
+                'input .forum-new-post-form #discussion-forum-title': 'toggleSubmitButton',
                 'submit .forum-new-post-form': 'createPost',
                 'change .post-option-input': 'postOptionChange',
                 'change .js-group-select': 'groupOptionChange',
@@ -142,6 +144,16 @@
                 'keydown .wmd-button': function(event) {
                     return DiscussionUtil.handleKeypressInToolbar(event);
                 }
+            };
+
+            NewPostView.prototype.toggleSubmitButton = function () {
+              var lengthOfBody = this.$('.wmd-input').val().length;
+              var lengthOfTitle = this.$('#discussion-forum-title').val().length;
+              if (lengthOfBody > 0 && lengthOfTitle > 0){
+                this.$('.submit').prop('disabled', false);
+              } else {
+                this.$('.submit').prop('disabled', true);
+              }
             };
 
             NewPostView.prototype.toggleGroupDropdown = function($target) {

--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -69,7 +69,7 @@
         <% } %>
     </div>
     <div>
-        <button type="submit" class="btn btn-primary submit"><%- gettext('Submit') %></button>
+        <button type="submit" class="btn btn-primary submit" disabled><%- gettext('Submit') %></button>
         <button type="button" class="btn btn-outline-primary cancel"><%- gettext('Cancel') %></button>
     </div>
 </form>


### PR DESCRIPTION
This PR Contains:

Jira ticket [Link](https://edlyio.atlassian.net/browse/EDS-113)

- While adding a new post in discussion submit button is clickable whether the comment title or body has some text or not. This PR change this functionality and now by default the button will be disabled until the user has entered some text in both of them as these both fields are required field.

![image](https://user-images.githubusercontent.com/23108499/69217719-15ac5380-0b91-11ea-9b5a-ed9c76ce2aa6.png)

![image](https://user-images.githubusercontent.com/23108499/69217758-28bf2380-0b91-11ea-9592-82e4183ee4bd.png)
