### PR TITLE
Make response and comment submit  button un-clickable

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -65,7 +65,8 @@
                 'click .add-response-btn': 'scrollToAddResponse',
                 'keydown .wmd-button': function(event) {
                     return DiscussionUtil.handleKeypressInToolbar(event);
-                }
+                },
+                'input .discussion-reply-new .wmd-input': 'toggleResponseSubmitButton'
             };
 
             DiscussionThreadView.prototype.$ = function(selector) {
@@ -345,7 +346,15 @@
             DiscussionThreadView.prototype.endorseThread = function() {
                 return this.model.set('endorsed', this.$el.find('.action-answer.is-checked').length > 0);
             };
-
+            DiscussionThreadView.prototype.toggleResponseSubmitButton = function(event) {
+                var post_button = $('.discussion-submit-post');
+                if (event.target.value.length) {
+                    post_button.attr('disabled', false);
+                }
+                else {
+                    post_button.attr('disabled', true);
+                }
+            }
             DiscussionThreadView.prototype.submitComment = function(event) {
                 var body, comment, url, view;
                 event.preventDefault();
@@ -372,6 +381,7 @@
                 });
                 this.model.addComment();
                 this.renderAddResponseButton();
+                event.target.disabled = true
                 return DiscussionUtil.safeAjax({
                     $elem: $(event.target),
                     url: url,

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -51,7 +51,8 @@
 
             ThreadResponseView.prototype.events = {
                 'click .discussion-submit-comment': 'submitComment',
-                'focus .wmd-input': 'showEditorChrome'
+                'focus .wmd-input': 'showEditorChrome',
+                'input .wmd-input': 'toggleCommentSubmitButton'
             };
 
             ThreadResponseView.prototype.$ = function(selector) {
@@ -181,6 +182,18 @@
                 return view;
             };
 
+            ThreadResponseView.prototype.toggleCommentSubmitButton = function(event) {
+                var id = event.target.id.split('-').slice(-1)[0];
+                var query_selector = 'form[data-id="'+ id +'"] .discussion-submit-comment';
+                var comment_button = document.querySelector(query_selector);
+                if (event.target.value.length > 0) {
+                    comment_button.disabled = false;
+                }
+                else {
+                    comment_button.disabled = true;
+                }
+            };
+
             ThreadResponseView.prototype.submitComment = function(event) {
                 var body, comment, url, view;
                 event.preventDefault();
@@ -201,6 +214,7 @@
                 view = this.renderComment(comment);
                 this.hideEditorChrome();
                 this.trigger('comment:add', comment);
+                event.target.disabled = true;
                 return DiscussionUtil.safeAjax({
                     $elem: $(event.target),
                     url: url,

--- a/common/static/common/templates/discussion/thread-response.underscore
+++ b/common/static/common/templates/discussion/thread-response.underscore
@@ -15,7 +15,7 @@
                 <div class="comment-body" id="add-new-comment-<%- wmdId %>" data-id="<%- wmdId %>"
                 data-placeholder="<%- gettext('Add a comment') %>"></div>
                 <div class="comment-post-control">
-                    <button class="btn btn-primary discussion-submit-comment control-button"><%- gettext("Submit") %></button>
+                    <button class="btn btn-primary discussion-submit-comment control-button" disabled><%- gettext("Submit") %></button>
                 </div>
             </form>
         <% } %>

--- a/common/static/common/templates/discussion/thread.underscore
+++ b/common/static/common/templates/discussion/thread.underscore
@@ -29,7 +29,7 @@
                 <ul class="discussion-errors"></ul>
                 <div class="reply-body" data-id="<%- id %>"></div>
                 <div class="reply-post-control">
-                    <button class="btn btn-outline-primary discussion-submit-post control-button"><%- gettext("Submit") %></button>
+                    <button class="btn btn-outline-primary discussion-submit-post control-button" disabled><%- gettext("Submit") %></button>
                 </div>
             </form>
             <% } %>


### PR DESCRIPTION
**Ticket Links:**

https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=EDS&modal=detail&selectedIssue=EDS-114

https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=EDS&modal=detail&selectedIssue=EDS-115

**Description:**

Make Response/Comment submit button un-clickable until the user adds any text in the field.